### PR TITLE
Configurable the donate button on the navigation menu bar.

### DIFF
--- a/app/src/Lay/Main.hbs
+++ b/app/src/Lay/Main.hbs
@@ -242,20 +242,22 @@
 
 		<div class="text-right">
 			{{#if CredUser}}
-			<div id="ColWelcome" class="d-flex align-items-center">
-				<div class="d-none d-md-block">
-					<span class="header-main-text">Welcome<br>{{CredUser.NameLogin}}!</span>
-				</div>
-				<div id="ColDonate" class="mr-2">
-					<a target="_blank" class="btn header-button-orange ml-2" href="https://cultivatefoodconnections.org/donate">
-						<span class="Tip" data-toggle="tooltip" data-placement="top" data-html="true"
-							title="Donate to support our open source work."
-						>
-							Donate
-						</span>
-					</a>
-				</div>
-			</div>
+				{{#if (hCkAnd CoopParams.DonateWebsite CoopParams.DonateButtonText CoopParams.DonateButtonTooltip) }}
+					<div id="ColWelcome" class="d-flex align-items-center">
+						<div class="d-none d-md-block">
+							<span class="header-main-text">Welcome<br>{{CredUser.NameLogin}}!</span>
+						</div>
+						<div id="ColDonate" class="mr-2">
+							<a target="_blank" class="btn header-button-orange ml-2" href="{{CoopParams.DonateWebsite}}">
+								<span class="Tip" data-toggle="tooltip" data-placement="top" data-html="true"
+									title="{{CoopParams.DonateButtonTooltip}}"
+								>
+									{{CoopParams.DonateButtonText}}
+								</span>
+							</a>
+						</div>
+					</div>
+				{{/if}}
 			{{else}}
 			<div id="ColWelcome" class="d-flex align-items-center">
 				<div class="d-none d-md-block text-left mr-5">

--- a/sanity/schemaFields/coopDetailsFields.ts
+++ b/sanity/schemaFields/coopDetailsFields.ts
@@ -1,3 +1,4 @@
+import {CheckmarkCircleIcon} from '@sanity/icons'
 import {defineField} from 'sanity'
 
 export const mainInfoFileds = [
@@ -292,5 +293,51 @@ export const socialMediaFields = [
         scheme: ['http', 'https'],
         allowRelative: false,
       }),
+  }),
+]
+
+export const donateDetailsFields = [
+  defineField({
+    title: 'Tip!',
+    description: `This button is optional.
+           It is designed to act as a Donate button in the navigation header, but it can be used for any other purpose.
+           When the external website is filled out the donate button will be shown
+           in the navigation header when the user is logged in.
+           Make sure to fill out all the fields if you want to use it.
+           `,
+    name: 'donateDetailsNote',
+    fieldset: 'donateDetails',
+    type: 'note',
+    options: {
+      icon: CheckmarkCircleIcon,
+      tone: 'positive',
+    },
+  }),
+  defineField({
+    name: 'DonateWebsite',
+    title: 'Donate Website',
+    description: 'Website address for your external donate page.',
+    type: 'url',
+    fieldset: 'donateDetails',
+    validation: (Rule) =>
+      Rule.uri({
+        scheme: ['http', 'https'],
+        allowRelative: false,
+      }),
+  }),
+  defineField({
+    name: 'DonateButtonText',
+    title: 'Donate Button Text',
+    description: 'Text for the donate button.',
+    type: 'string',
+    fieldset: 'donateDetails',
+    validation: (Rule) => Rule.max(10).error('Text is too long'),
+  }),
+  defineField({
+    name: 'DonateButtonTooltip',
+    title: 'Donate Button Tooltip',
+    description: 'Tooltip for the donate button.',
+    type: 'string',
+    fieldset: 'donateDetails',
   }),
 ]

--- a/sanity/schemaTypes/coopDetails.ts
+++ b/sanity/schemaTypes/coopDetails.ts
@@ -1,6 +1,7 @@
 import {HomeIcon} from '@sanity/icons'
 import {defineType} from 'sanity'
 import {
+  donateDetailsFields,
   emailAddressesFields,
   externalWebsitesFields,
   mainImages,
@@ -43,6 +44,11 @@ export const coopDetails = defineType(
         name: 'socialMedia',
         options: {collapsible: true, collapsed: true},
       },
+      {
+        title: 'Donate Details',
+        name: 'donateDetails',
+        options: {collapsible: true, collapsed: true},
+      },
     ],
     fields: [
       ...mainInfoFileds,
@@ -50,6 +56,7 @@ export const coopDetails = defineType(
       ...externalWebsitesFields,
       ...mainImages,
       ...socialMediaFields,
+      ...donateDetailsFields,
     ],
   },
   {strict: false},


### PR DESCRIPTION
The "Donate" button should be configurable.
I decide to make it more flexible and it can be used for any purposes, hence both the button text and the tooltip can be set.
Otherwise it's just a button that opens an external site.

**Note**
Currently the donate button is only shown when the user is logged in, otherwise the "Start free trial" button is shown. Due to the (lack of) design this is good enough, but later on can be changed.
The `Tip` section within Sanity describes this.

<img width="425" height="187" alt="image" src="https://github.com/user-attachments/assets/cead4f1c-2094-4108-9842-e52150b8593e" />
