### PR TITLE
reduce mail timeout to 5 seconds from 60

### DIFF
--- a/app/src/Email.js
+++ b/app/src/Email.js
@@ -63,7 +63,7 @@ export async function wSend(aMsg, retryCount = 0) {
     console.error(`Error in sending email: ${error}`);
     if (retryCount < 3) {
       // If email sending fails, wait 5 seconds and then try again
-      await new Promise(resolve => setTimeout(resolve, 60000));
+      await new Promise(resolve => setTimeout(resolve, 5000));
       await wSend(aMsg, retryCount + 1);
     } else {
       // If email sending fails 3 times, log the failure and give up


### PR DESCRIPTION
We've had an issue with mail timeouts when advancing cycles, this should make sure that we don't crash the application in that case.