### PR TITLE
Fix: About Producers page

### DIFF
--- a/app/src/Page/Home/about-producer.hbs
+++ b/app/src/Page/Home/about-producer.hbs
@@ -57,7 +57,13 @@
 	<div class="row my-3">
 		{{#if NameImgProducer}}
 		<div class="col-md-4">
-			{{>Product/pImageCarousel}}
+			<div class="form-group bg-white">
+				{{!-- Some white-background logos have no padding of their own, and they
+				//    look better with 'p-2' or something similar. Others have dark
+				//    backgrounds, however, and they look worse: --}}
+				<img src="{{hPrefixImageWithStorage NameImgProducer}}" alt="Producer image"
+					class="w-100 border rounded p-0" >
+			</div>
 		</div>
 		{{/if}}
 

--- a/app/src/Page/Shop/product.js
+++ b/app/src/Page/Shop/product.js
@@ -24,9 +24,6 @@ export async function wHandGet(aReq, aResp) {
   // Fetch all images for this product
   const oImages = await wProductImages(oIDProduct);
 
-  // Debug: verify what images were loaded
-  console.log(`�️  Loaded images for product ${oIDProduct}:`, oImages);
-
   const oProduct = { ...oProductsRoll[0], ...oQtysWeb, Images: oImages };
   if (aResp.locals.CredImperUser?.IDMemb)
     await wPopulateIsFavorited(aResp.locals.CredImperUser.IDMemb, [oProduct]);
@@ -74,7 +71,6 @@ export async function wProductImages(aIDProduct) {
   const [oRows] = await Conn.wExecPrep(oSQL, oParams);
   return oRows.map(row => row.FileName);
 }
-
 
 /** Returns the total listed variety offer and promise quantities for the
  *  specified product, or zeros if the product is not found. */


### PR DESCRIPTION
Producer image: 
- Set the first image as the producer's image: currently not supporting multiple producer images - not sure if it makes sense to have multiple images for a producer - that's a logo basically.

- Show the product images. Use a carousel there.

Before:
<img width="810" height="782" alt="image" src="https://github.com/user-attachments/assets/ce8e8bc1-ccac-42ea-92e4-429ae1648076" />


After:
(imagine that the product images are show, but I don't have them in local 🙈 )
<img width="914" height="799" alt="image" src="https://github.com/user-attachments/assets/31f0822c-8a1e-44f1-bdd6-04d7e4e69c0c" />
